### PR TITLE
Update files , delete files, authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ $env:ENDPOINT='http://host.docker.internal:4566'
 npm ci
 localstack start
 npm run sls deploy
-$env:BASE_URL='http://localhost:4566/restapis/3ojfyrsn1f/dev/_user_request_'
+$env:BASE_URL=
 python -m src.main

--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ Install the requirements: `python -m pip install -r requirements.txt`
 Run: `BASE_URL=<your deployed url> python -m src.main`
 
 Example: `BASE_URL='http://localhost:4566/restapis/3ojfyrsn1f/dev/_user_request_' python -m src.main`
+
+
+# Win
+
+$env:ENDPOINT='http://host.docker.internal:4566'
+npm ci
+localstack start
+npm run sls deploy
+$env:BASE_URL='http://localhost:4566/restapis/3ojfyrsn1f/dev/_user_request_'
+python -m src.main

--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ localstack start
 npm run sls deploy
 $env:BASE_URL=
 python -m src.main
+npm run sls -- deploy function --function deleteFile

--- a/serverless.yml
+++ b/serverless.yml
@@ -117,11 +117,15 @@ resources:
       Properties:
         TableName: file_meta
         AttributeDefinitions:
-          - AttributeName: name
+          - AttributeName: username
+            AttributeType: S
+          - AttributeName: uuid
             AttributeType: S
         KeySchema:
-          - AttributeName: name
+          - AttributeName: username
             KeyType: HASH
+          - AttributeName: uuid
+            KeyType: RANGE
         ProvisionedThroughput:
           ReadCapacityUnits: 5
           WriteCapacityUnits: 5

--- a/serverless.yml
+++ b/serverless.yml
@@ -87,6 +87,15 @@ functions:
       - http:
           path: file
           method: post
+  updateFile:
+    handler: src/lambdas/lambda_update_file.lambda_update_file
+    package:
+      patterns:
+        - 'src/lambdas/lambda_update_file.py'
+    events:
+      - http:
+          path: file
+          method: put
 
 resources:
   Resources:

--- a/serverless.yml
+++ b/serverless.yml
@@ -96,6 +96,15 @@ functions:
       - http:
           path: file
           method: put
+  deleteFile:
+    handler: src/lambdas/lambda_delete_file.lambda_delete_file
+    package:
+      patterns:
+        - 'src/lambdas/lambda_delete_file.py'
+    events:
+      - http:
+          path: file
+          method: delete   
 
 resources:
   Resources:

--- a/src/gui/dashboard/overview_screen.py
+++ b/src/gui/dashboard/overview_screen.py
@@ -3,7 +3,9 @@ from dataclasses import dataclass
 from PyQt6.QtWidgets import *
 from PyQt6.QtGui import *
 from PyQt6.QtCore import *
+import requests
 
+from src.gui.common import show_success, show_error
 from src.service.update_file import update_file
 from src.service.upload_file import FileData
 from src.service.list_files import list_files
@@ -174,8 +176,11 @@ class FileEdit(QGroupBox):
         uuid = self.file_uuid
         
         QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
-        delete_file(uuid)
+        result: requests.Response = delete_file(uuid)
         QApplication.restoreOverrideCursor()
+
+        if result.status_code in [401, 403, 404]:
+            show_error(result.json())
 
 
 

--- a/src/gui/dashboard/overview_screen.py
+++ b/src/gui/dashboard/overview_screen.py
@@ -19,9 +19,10 @@ class FileEdit(QGroupBox):
     btn_tag_add: QPushButton
     btn_tag_rem: QPushButton
     lst_tags: QListWidget
+    btn_switch_file: QPushButton
     lbl_size: QLabel
     owner: "OverviewScreen"
-
+    new_fname: str
     tags: List[str]
 
     def __init__(self, owner: "OverviewScreen"):
@@ -33,6 +34,7 @@ class FileEdit(QGroupBox):
 
     def init_gui(self):
         self.real_name = ""
+        self.new_fname = None
         self.tags = []
         self.txt_name = QLineEdit()
         self.txt_desc = QTextEdit()
@@ -44,6 +46,7 @@ class FileEdit(QGroupBox):
         self.lbl_modify_date = QLabel()
         self.lbl_size = QLabel()
         self.btn_update = QPushButton("Save Changes")
+        self.btn_switch_file = QPushButton("Change File")
 
         self.txt_tag.setPlaceholderText("Enter tag name")
         self.txt_tag.textEdited.connect(self.set_btn_tag_add_enabled)
@@ -88,6 +91,8 @@ class FileEdit(QGroupBox):
         layout_main.addLayout(h3)
 
         layout_main.addItem(QSpacerItem(1, 1, QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Expanding))
+
+        layout_main.addWidget(self.btn_switch_file)
         layout_main.addWidget(self.btn_update)
 
         self.setLayout(layout_main)
@@ -115,8 +120,10 @@ class FileEdit(QGroupBox):
             new_tags.append(self.lst_tags.item(x).text())
 
         QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
-        update_file(self.real_name, new_name, new_desc, new_tags)
+        update_file(self.real_name, new_name, new_desc, new_tags, self.new_fname)
         QApplication.restoreOverrideCursor()
+        
+        self.new_fname = ""
 
     def set_btn_tag_add_enabled(self):
         if self.txt_tag.text().strip() == "":
@@ -141,6 +148,13 @@ class FileEdit(QGroupBox):
         for row in selected_rows:
             self.tags.remove(self.tags[row])
             self.lst_tags.takeItem(row)
+
+    def pick_file(self):
+        fname, _ = QFileDialog.getOpenFileName(self, 'Open File')
+        if fname == "":
+            self.new_fname = None
+        else:
+            self.new_fname = fname
 
 
 @dataclass

--- a/src/gui/dashboard/overview_screen.py
+++ b/src/gui/dashboard/overview_screen.py
@@ -4,6 +4,7 @@ from PyQt6.QtWidgets import *
 from PyQt6.QtGui import *
 from PyQt6.QtCore import *
 
+from src.service.update_file import update_file
 from src.service.upload_file import list_files, FileData
 
 @dataclass
@@ -32,7 +33,6 @@ class FileEdit(QGroupBox):
         self.lbl_modify_date = QLabel()
         self.lbl_size = QLabel()
         self.btn_update = QPushButton("Save Changes")
-        self.btn_update.setEnabled(False)
 
     def init_layout(self):
         layout_main = QVBoxLayout()
@@ -48,6 +48,8 @@ class FileEdit(QGroupBox):
         h3 = QHBoxLayout()
         h3.addWidget(QLabel("Modified: "))
         h3.addWidget(self.lbl_modify_date)
+
+        self.btn_update.clicked.connect(self.on_click_update)
 
         layout_main.addWidget(QLabel("Name:"))
         layout_main.addWidget(self.txt_name)
@@ -75,6 +77,18 @@ class FileEdit(QGroupBox):
         self.lst_tags.clear()
         for tag in file.tags:
             self.lst_tags.addItem(QListWidgetItem(tag))
+
+    def on_click_update(self):
+        new_name: str = self.txt_name.text()
+        new_desc: str = self.txt_desc.toPlainText()
+
+        new_tags = []
+        for x in range(self.lst_tags.count()):
+            new_tags.append(self.lst_tags.item(x).text())
+
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        update_file(new_name, new_desc, new_tags)
+        QApplication.restoreOverrideCursor()
 
 
 @dataclass

--- a/src/gui/dashboard/overview_screen.py
+++ b/src/gui/dashboard/overview_screen.py
@@ -15,9 +15,14 @@ class FileEdit(QGroupBox):
     btn_update: QPushButton
     lbl_upload_date: QLabel
     lbl_modify_date: QLabel
+    txt_tag: QLineEdit
+    btn_tag_add: QPushButton
+    btn_tag_rem: QPushButton
     lst_tags: QListWidget
     lbl_size: QLabel
     owner: "OverviewScreen"
+
+    tags: List[str]
 
     def __init__(self, owner: "OverviewScreen"):
         QGroupBox.__init__(self)
@@ -28,13 +33,25 @@ class FileEdit(QGroupBox):
 
     def init_gui(self):
         self.real_name = ""
+        self.tags = []
         self.txt_name = QLineEdit()
         self.txt_desc = QTextEdit()
+        self.txt_tag = QLineEdit()
+        self.btn_tag_add = QPushButton('Add Tag')
+        self.btn_tag_rem = QPushButton('Remove Tag')
         self.lst_tags = QListWidget()
         self.lbl_upload_date = QLabel()
         self.lbl_modify_date = QLabel()
         self.lbl_size = QLabel()
         self.btn_update = QPushButton("Save Changes")
+
+        self.txt_tag.setPlaceholderText("Enter tag name")
+        self.txt_tag.textEdited.connect(self.set_btn_tag_add_enabled)
+        self.btn_tag_add.clicked.connect(self.add_tag)
+        self.btn_tag_add.clicked.connect(self.set_btn_tag_add_enabled)
+        self.btn_tag_rem.clicked.connect(self.rem_tag)
+        self.lst_tags.itemSelectionChanged.connect(self.set_btn_tag_rem_enabled)
+        self.btn_update.clicked.connect(self.on_click_update)
 
     def init_layout(self):
         layout_main = QVBoxLayout()
@@ -51,14 +68,21 @@ class FileEdit(QGroupBox):
         h3.addWidget(QLabel("Modified: "))
         h3.addWidget(self.lbl_modify_date)
 
-        self.btn_update.clicked.connect(self.on_click_update)
-
         layout_main.addWidget(QLabel("Name:"))
         layout_main.addWidget(self.txt_name)
         layout_main.addWidget(QLabel("Description:"))
         layout_main.addWidget(self.txt_desc)
+
         layout_main.addWidget(QLabel("Tags:"))
+
+        h4 = QHBoxLayout()
+        h4.addWidget(self.txt_tag)
+        h4.addWidget(self.btn_tag_add)
+        h4.addWidget(self.btn_tag_rem)
+
+        layout_main.addLayout(h4)
         layout_main.addWidget(self.lst_tags)
+
         layout_main.addLayout(h1)
         layout_main.addLayout(h2)
         layout_main.addLayout(h3)
@@ -80,6 +104,7 @@ class FileEdit(QGroupBox):
         self.lst_tags.clear()
         for tag in file.tags:
             self.lst_tags.addItem(QListWidgetItem(tag))
+            self.tags.append(tag)
 
     def on_click_update(self):
         new_name: str = self.txt_name.text()
@@ -92,6 +117,30 @@ class FileEdit(QGroupBox):
         QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
         update_file(self.real_name, new_name, new_desc, new_tags)
         QApplication.restoreOverrideCursor()
+
+    def set_btn_tag_add_enabled(self):
+        if self.txt_tag.text().strip() == "":
+            self.btn_tag_add.setEnabled(False)
+        else:
+            self.btn_tag_add.setEnabled(True)  
+
+    def set_btn_tag_rem_enabled(self):
+        if len(self.lst_tags.selectedIndexes()) == 0:
+            self.btn_tag_rem.setEnabled(False)
+        else:
+            self.btn_tag_rem.setEnabled(True)
+
+    def add_tag(self):
+        new_tag = self.txt_tag.text()
+        self.tags.append(new_tag)
+        self.lst_tags.addItem(QListWidgetItem(new_tag))
+        self.txt_tag.setText("")
+
+    def rem_tag(self):
+        selected_rows = [t.row() for t in self.lst_tags.selectedIndexes()]
+        for row in selected_rows:
+            self.tags.remove(self.tags[row])
+            self.lst_tags.takeItem(row)
 
 
 @dataclass

--- a/src/gui/dashboard/overview_screen.py
+++ b/src/gui/dashboard/overview_screen.py
@@ -5,7 +5,8 @@ from PyQt6.QtGui import *
 from PyQt6.QtCore import *
 
 from src.service.update_file import update_file
-from src.service.upload_file import list_files, FileData
+from src.service.upload_file import FileData
+from src.service.list_files import list_files
 from src.service.delete_file import delete_file
 
 @dataclass

--- a/src/gui/dashboard/overview_screen.py
+++ b/src/gui/dashboard/overview_screen.py
@@ -9,6 +9,7 @@ from src.service.upload_file import list_files, FileData
 
 @dataclass
 class FileEdit(QGroupBox):
+    real_name: str
     txt_name: QLineEdit
     txt_desc: QTextEdit
     btn_update: QPushButton
@@ -26,6 +27,7 @@ class FileEdit(QGroupBox):
         self.init_layout()
 
     def init_gui(self):
+        self.real_name = ""
         self.txt_name = QLineEdit()
         self.txt_desc = QTextEdit()
         self.lst_tags = QListWidget()
@@ -68,6 +70,7 @@ class FileEdit(QGroupBox):
 
     def on_selected_file(self, file: FileData):
         self.txt_name.setText(file.name)
+        self.real_name = file.name
         self.txt_desc.setText(file.desc)
         
         self.lbl_size.setText(f"{file.size} B")
@@ -87,7 +90,7 @@ class FileEdit(QGroupBox):
             new_tags.append(self.lst_tags.item(x).text())
 
         QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
-        update_file(new_name, new_desc, new_tags)
+        update_file(self.real_name, new_name, new_desc, new_tags)
         QApplication.restoreOverrideCursor()
 
 

--- a/src/gui/dashboard/overview_screen.py
+++ b/src/gui/dashboard/overview_screen.py
@@ -6,6 +6,7 @@ from PyQt6.QtCore import *
 
 from src.service.update_file import update_file
 from src.service.upload_file import list_files, FileData
+from src.service.delete_file import delete_file
 
 @dataclass
 class FileEdit(QGroupBox):
@@ -20,6 +21,7 @@ class FileEdit(QGroupBox):
     btn_tag_rem: QPushButton
     lst_tags: QListWidget
     btn_switch_file: QPushButton
+    btn_delete: QPushButton
     lbl_size: QLabel
     owner: "OverviewScreen"
     new_fname: str
@@ -47,6 +49,7 @@ class FileEdit(QGroupBox):
         self.lbl_size = QLabel()
         self.btn_update = QPushButton("Save Changes")
         self.btn_switch_file = QPushButton("Pick Different File")
+        self.btn_delete = QPushButton("Delete")
 
         self.txt_tag.setPlaceholderText("Enter tag name")
         self.txt_tag.textEdited.connect(self.set_btn_tag_add_enabled)
@@ -55,6 +58,7 @@ class FileEdit(QGroupBox):
         self.btn_tag_rem.clicked.connect(self.rem_tag)
         self.lst_tags.itemSelectionChanged.connect(self.set_btn_tag_rem_enabled)
         self.btn_switch_file.clicked.connect(self.pick_file)
+        self.btn_delete.clicked.connect(self.delete_file)
         self.btn_update.clicked.connect(self.on_click_update)
 
     def init_layout(self):
@@ -95,6 +99,7 @@ class FileEdit(QGroupBox):
 
         layout_main.addWidget(self.btn_switch_file)
         layout_main.addWidget(self.btn_update)
+        layout_main.addWidget(self.btn_delete)
 
         self.setLayout(layout_main)
 
@@ -163,6 +168,14 @@ class FileEdit(QGroupBox):
             self.new_fname = None
         else:
             self.new_fname = fname
+
+    def delete_file(self):
+        uuid = self.file_uuid
+        
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        delete_file(uuid)
+        QApplication.restoreOverrideCursor()
+
 
 
 @dataclass

--- a/src/gui/dashboard/overview_screen.py
+++ b/src/gui/dashboard/overview_screen.py
@@ -46,7 +46,7 @@ class FileEdit(QGroupBox):
         self.lbl_modify_date = QLabel()
         self.lbl_size = QLabel()
         self.btn_update = QPushButton("Save Changes")
-        self.btn_switch_file = QPushButton("Change File")
+        self.btn_switch_file = QPushButton("Pick Different File")
 
         self.txt_tag.setPlaceholderText("Enter tag name")
         self.txt_tag.textEdited.connect(self.set_btn_tag_add_enabled)
@@ -54,6 +54,7 @@ class FileEdit(QGroupBox):
         self.btn_tag_add.clicked.connect(self.set_btn_tag_add_enabled)
         self.btn_tag_rem.clicked.connect(self.rem_tag)
         self.lst_tags.itemSelectionChanged.connect(self.set_btn_tag_rem_enabled)
+        self.btn_switch_file.clicked.connect(self.pick_file)
         self.btn_update.clicked.connect(self.on_click_update)
 
     def init_layout(self):
@@ -125,7 +126,8 @@ class FileEdit(QGroupBox):
             self.file_uuid,
             new_name,
             new_desc,
-            new_tags
+            new_tags,
+            self.new_fname
         )
         QApplication.restoreOverrideCursor()
         

--- a/src/gui/dashboard/overview_screen.py
+++ b/src/gui/dashboard/overview_screen.py
@@ -9,7 +9,7 @@ from src.service.upload_file import list_files, FileData
 
 @dataclass
 class FileEdit(QGroupBox):
-    real_name: str
+    file_uuid: str
     txt_name: QLineEdit
     txt_desc: QTextEdit
     btn_update: QPushButton
@@ -33,7 +33,7 @@ class FileEdit(QGroupBox):
         self.init_layout()
 
     def init_gui(self):
-        self.real_name = ""
+        self.file_uuid = ""
         self.new_fname = None
         self.tags = []
         self.txt_name = QLineEdit()
@@ -99,7 +99,7 @@ class FileEdit(QGroupBox):
 
     def on_selected_file(self, file: FileData):
         self.txt_name.setText(file.name)
-        self.real_name = file.name
+        self.file_uuid = file.uuid
         self.txt_desc.setText(file.desc)
         
         self.lbl_size.setText(f"{file.size} B")
@@ -120,7 +120,13 @@ class FileEdit(QGroupBox):
             new_tags.append(self.lst_tags.item(x).text())
 
         QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
-        update_file(self.real_name, new_name, new_desc, new_tags, self.new_fname)
+
+        update_file(
+            self.file_uuid,
+            new_name,
+            new_desc,
+            new_tags
+        )
         QApplication.restoreOverrideCursor()
         
         self.new_fname = ""

--- a/src/lambdas/common.py
+++ b/src/lambdas/common.py
@@ -43,16 +43,13 @@ def dynamo_obj_to_python_obj(dynamo_obj: dict) -> dict:
     }
 
 
+def verify_user(token: str) -> None:
+    pass
+
+
 def http_response(body, status_code: int) -> dict:
     return {
-        "body": json.dumps(body, default=str),  # TODO: API Gateway does NOT
-        # allow the value to be just `body` i.e. a Python object (e.g. a list),
-        # and we HAVE TO convert it into a json string. This becomes a problem
-        # on the frontend where we then have to do json.loads(p['body']) even
-        # though p was already `json.loads`-ed. It's pointless. If we try to
-        # move the json.dumps(...) to wrap this entire return value i.e. the
-        # whole dictionary, then we would have to do json.loads() twice on the
-        # frontend when fetching lambda response payload.
+        "body": json.dumps(body, default=str),
         "isBase64Encoded": False,
         "statusCode": status_code,
         "headers": {

--- a/src/lambdas/common.py
+++ b/src/lambdas/common.py
@@ -1,4 +1,3 @@
-from typing import Dict
 import base64
 import json
 import boto3
@@ -67,13 +66,13 @@ def http_response(body, status_code: int) -> dict:
         }
     }
 
-def jwt_decode(headers: Dict) -> str:
+def jwt_decode(headers: dict) -> str:
     auth_header: str = headers['Authorization']
     parts = auth_header.split()
     jwt = parts[1]
 
     jwt_body_str: str = jwt.split('.')[1]
-    jwt_body: Dict = json.loads(base64url_decode(jwt_body_str))
+    jwt_body: dict = json.loads(base64url_decode(jwt_body_str))
     username = jwt_body['username']
 
     return username

--- a/src/lambdas/common.py
+++ b/src/lambdas/common.py
@@ -8,7 +8,8 @@ from boto3.dynamodb.types import TypeSerializer, TypeDeserializer
 
 CONTENT_BUCKET_NAME = environ["CONTENT_BUCKET_NAME"]
 CONTENT_METADATA_TB_NAME = environ["CONTENT_METADATA_TB_NAME"]
-CONTENT_METADATA_TB_PK = "name"
+CONTENT_METADATA_TB_PK = "username"
+CONTENT_METADATA_TB_SK = "uuid"
 
 USER_TB_NAME = environ["USER_TB_NAME"]
 USER_TB_PK = "username"

--- a/src/lambdas/lambda_delete_file.py
+++ b/src/lambdas/lambda_delete_file.py
@@ -1,9 +1,25 @@
 from typing import Dict
 from .common import *
+import base64
+
+def base64url_decode(input):
+    return base64.urlsafe_b64decode(input + '==')
+
+
+def manage_token(auth_header: str) -> str:
+    parts = auth_header.split()
+    jwt = parts[1]
+
+    jwt_body_str: str = jwt.split('.')[1]
+    jwt_body: Dict = json.loads(base64url_decode(jwt_body_str))
+    username = jwt_body['username']
+
+    return username
 
 
 def lambda_delete_file(event: Dict, context):
     body: Dict = json.loads(event['body'])
+    headers: Dict = event['headers']
     key = {
         CONTENT_METADATA_TB_PK: body['username'],
         CONTENT_METADATA_TB_SK: body['uuid']
@@ -18,5 +34,5 @@ def lambda_delete_file(event: Dict, context):
         Bucket=CONTENT_BUCKET_NAME,
         Key=key['uuid']
     )
-    
-    return http_response(None, 204)
+
+    return http_response(manage_token(headers['Authorization']), 200)

--- a/src/lambdas/lambda_delete_file.py
+++ b/src/lambdas/lambda_delete_file.py
@@ -20,9 +20,15 @@ def manage_token(auth_header: str) -> str:
 def lambda_delete_file(event: Dict, context):
     body: Dict = json.loads(event['body'])
     headers: Dict = event['headers']
+    file_uuid: str = body['uuid']
+
+    username: str = jwt_decode(headers)
+    if not user_exists(username):
+        return http_response("Forbidden", 401)
+
     key = {
-        CONTENT_METADATA_TB_PK: body['username'],
-        CONTENT_METADATA_TB_SK: body['uuid']
+        CONTENT_METADATA_TB_PK: username,
+        CONTENT_METADATA_TB_SK: file_uuid
     }
 
     dynamo_cli.delete_item(
@@ -35,4 +41,4 @@ def lambda_delete_file(event: Dict, context):
         Key=key['uuid']
     )
 
-    return http_response(manage_token(headers['Authorization']), 200)
+    return http_response(None, 204)

--- a/src/lambdas/lambda_delete_file.py
+++ b/src/lambdas/lambda_delete_file.py
@@ -1,20 +1,6 @@
 from .common import *
 import base64
 
-def base64url_decode(input):
-    return base64.urlsafe_b64decode(input + '==')
-
-
-def manage_token(auth_header: str) -> str:
-    parts = auth_header.split()
-    jwt = parts[1]
-
-    jwt_body_str: str = jwt.split('.')[1]
-    jwt_body: dict = json.loads(base64url_decode(jwt_body_str))
-    username = jwt_body['username']
-
-    return username
-
 
 def lambda_delete_file(event: dict, context):
     body: dict = json.loads(event['body'])

--- a/src/lambdas/lambda_delete_file.py
+++ b/src/lambdas/lambda_delete_file.py
@@ -20,11 +20,12 @@ def manage_token(auth_header: str) -> str:
 def lambda_delete_file(event: Dict, context):
     body: Dict = json.loads(event['body'])
     headers: Dict = event['headers']
-    file_uuid: str = body['uuid']
 
     username: str = jwt_decode(headers)
     if not user_exists(username):
         return http_response("Forbidden", 401)
+    
+    file_uuid: str = body['uuid']
 
     key = {
         CONTENT_METADATA_TB_PK: username,

--- a/src/lambdas/lambda_delete_file.py
+++ b/src/lambdas/lambda_delete_file.py
@@ -1,0 +1,22 @@
+from typing import Dict
+from .common import *
+
+
+def lambda_delete_file(event: Dict, context):
+    body: Dict = json.loads(event['body'])
+    key = {
+        CONTENT_METADATA_TB_PK: body['username'],
+        CONTENT_METADATA_TB_SK: body['uuid']
+    }
+
+    dynamo_cli.delete_item(
+        Key=python_obj_to_dynamo_obj(key),
+        TableName=CONTENT_METADATA_TB_NAME,
+    )
+
+    s3_cli.delete_object(
+        Bucket=CONTENT_BUCKET_NAME,
+        Key=key['uuid']
+    )
+    
+    return http_response(None, 204)

--- a/src/lambdas/lambda_delete_file.py
+++ b/src/lambdas/lambda_delete_file.py
@@ -24,7 +24,7 @@ def lambda_delete_file(event: dict, context):
     if not user_exists(username):
         return http_response("Forbidden", 401)
     
-    file_uuid: str = body['uuid']
+    file_uuid: str = body[CONTENT_METADATA_TB_SK]
 
     key = {
         CONTENT_METADATA_TB_PK: username,
@@ -38,7 +38,7 @@ def lambda_delete_file(event: dict, context):
 
     s3_cli.delete_object(
         Bucket=CONTENT_BUCKET_NAME,
-        Key=key['uuid']
+        Key=key[CONTENT_METADATA_TB_SK]
     )
 
     return http_response(None, 204)

--- a/src/lambdas/lambda_delete_file.py
+++ b/src/lambdas/lambda_delete_file.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from .common import *
 import base64
 
@@ -11,15 +10,15 @@ def manage_token(auth_header: str) -> str:
     jwt = parts[1]
 
     jwt_body_str: str = jwt.split('.')[1]
-    jwt_body: Dict = json.loads(base64url_decode(jwt_body_str))
+    jwt_body: dict = json.loads(base64url_decode(jwt_body_str))
     username = jwt_body['username']
 
     return username
 
 
-def lambda_delete_file(event: Dict, context):
-    body: Dict = json.loads(event['body'])
-    headers: Dict = event['headers']
+def lambda_delete_file(event: dict, context):
+    body: dict = json.loads(event['body'])
+    headers: dict = event['headers']
 
     username: str = jwt_decode(headers)
     if not user_exists(username):

--- a/src/lambdas/lambda_list_files.py
+++ b/src/lambdas/lambda_list_files.py
@@ -3,41 +3,23 @@ from .common import *
 
 
 def lambda_list_files(event: Dict, context):
+    body: Dict = json.loads(event['body'])
+    username: str = body['username']
+
+    response = dynamo_cli.query(
+        TableName=CONTENT_METADATA_TB_NAME,
+        KeyConditionExpression=f'{CONTENT_METADATA_TB_PK} = :pk',
+        ExpressionAttributeValues={
+            ':pk': {
+                'S': username,
+            },
+        }
+    )
+
+    items = response['Items']
+
     result = []
-
-    try:
-        response = s3_cli.list_objects(Bucket=CONTENT_BUCKET_NAME)
-    except s3_cli.exceptions.NoSuchBucket:
-        result = {
-            "message": f"No such bucket {CONTENT_BUCKET_NAME}" 
-        }
-        return http_response(result, 500)
-
-    contents = response.get('Contents')
-    if contents is None:
-        result = {
-            "message": f"No Contents in {CONTENT_BUCKET_NAME}" 
-        }
-        return http_response(result, 500)
-
-    for s3_file in contents:
-        dynamo_key = {CONTENT_METADATA_TB_PK: s3_file['Key']}
-        dynamo_key = python_obj_to_dynamo_obj(dynamo_key)
-        dynamo_res = dynamo_cli.get_item(TableName=CONTENT_METADATA_TB_NAME, Key=dynamo_key)
-        dynamo_item = dynamo_obj_to_python_obj(dynamo_res.get('Item'))
-
-        item = {
-            "name":s3_file['Key'],
-            "type":dynamo_item.get('type', ''),
-            "desc":dynamo_item.get('desc', ''),
-            "tags":dynamo_item.get('tags', []),
-            "size":dynamo_item.get('size', 0),
-            "upload_date":dynamo_item.get('uploadDate', ""),
-            "last_modified":dynamo_item.get('modificationDate', ""),
-            "creation_date":dynamo_item.get('creationDate', ""),
-        }
-
-        result.append(item)
-    result = sorted(result, key=lambda item: item['upload_date'], reverse=True)
+    for o in items:
+        result.append(dynamo_obj_to_python_obj(o))
 
     return http_response(result, 200)

--- a/src/lambdas/lambda_list_files.py
+++ b/src/lambdas/lambda_list_files.py
@@ -4,7 +4,11 @@ from .common import *
 
 def lambda_list_files(event: Dict, context):
     body: Dict = json.loads(event['body'])
-    username: str = body['username']
+    headers: Dict = event['headers']
+
+    username: str = jwt_decode(headers)
+    if not user_exists(username):
+        return http_response("Forbidden", 401)
 
     response = dynamo_cli.query(
         TableName=CONTENT_METADATA_TB_NAME,

--- a/src/lambdas/lambda_list_files.py
+++ b/src/lambdas/lambda_list_files.py
@@ -1,10 +1,10 @@
-from typing import Dict
+
 from .common import *
 
 
-def lambda_list_files(event: Dict, context):
-    body: Dict = json.loads(event['body'])
-    headers: Dict = event['headers']
+def lambda_list_files(event: dict, context):
+    body: dict = json.loads(event['body'])
+    headers: dict = event['headers']
 
     username: str = jwt_decode(headers)
     if not user_exists(username):

--- a/src/lambdas/lambda_login.py
+++ b/src/lambdas/lambda_login.py
@@ -1,6 +1,6 @@
 import hashlib
 import hmac
-from typing import Dict
+
 from .common import *
 
 SECRET = "verysecret"
@@ -21,8 +21,8 @@ def jwt_creator(username: str):
     return token
 
 
-def lambda_login(event: Dict, context):
-    body: Dict = json.loads(event['body'])
+def lambda_login(event: dict, context):
+    body: dict = json.loads(event['body'])
     username = body['username']
     password = body['password']
 

--- a/src/lambdas/lambda_login.py
+++ b/src/lambdas/lambda_login.py
@@ -1,21 +1,9 @@
-import base64
 import hashlib
 import hmac
 from typing import Dict
 from .common import *
 
 SECRET = "verysecret"
-
-
-# https://stackoverflow.com/a/68409773
-def base64url_decode(input):
-    return base64.urlsafe_b64decode(input + '==')
-
-
-def base64url_encode(input):
-    stringAsBytes = input.encode('ascii')
-    stringAsBase64 = base64.urlsafe_b64encode(stringAsBytes).decode('utf-8').replace('=', '')
-    return stringAsBase64
 
 
 def jwt_creator(username: str):

--- a/src/lambdas/lambda_register.py
+++ b/src/lambdas/lambda_register.py
@@ -1,12 +1,12 @@
-from typing import Dict
+
 from botocore.exceptions import ClientError
 from .common import *
 
 
-def lambda_register(event: Dict, context):
-    body: Dict = json.loads(event['body'])
-    user_data: Dict = body
-    user_data_ddb: Dict = python_obj_to_dynamo_obj(user_data)
+def lambda_register(event: dict, context):
+    body: dict = json.loads(event['body'])
+    user_data: dict = body
+    user_data_ddb: dict = python_obj_to_dynamo_obj(user_data)
 
     try:
         dynamo_cli.put_item(

--- a/src/lambdas/lambda_update_file.py
+++ b/src/lambdas/lambda_update_file.py
@@ -6,7 +6,6 @@ def lambda_update_file(event: Dict, context):
     body: Dict = json.loads(event['body'])
     metadata: Dict = body['metadata']
 
-
     # TODO: This doesn't change the name. We can't change it normally since 
     # it's a partition key. Change the dynamodb structure!
 
@@ -52,5 +51,24 @@ def lambda_update_file(event: Dict, context):
         ExpressionAttributeNames=expression_attr_names,
         ExpressionAttributeValues=python_obj_to_dynamo_obj(expression_attr_vals)
     )
+
+    #########
+
+    # Update the file content (if possible)
+
+    ## TODO: Split into 2 functions, one for meta only, other for file
+
+    # data: bytes = base64.b64decode(body['data'])
+
+    # dynamo_cli.put_item(
+    #     TableName=CONTENT_METADATA_TB_NAME,
+    #     Item=metadata_dynamojson
+    # )
+
+    # s3_cli.upload_fileobj(
+    #     Fileobj=io.BytesIO(data),
+    #     Bucket=CONTENT_BUCKET_NAME,
+    #     Key=metadata['name']
+    # )
 
     return http_response(None, 204)

--- a/src/lambdas/lambda_update_file.py
+++ b/src/lambdas/lambda_update_file.py
@@ -29,8 +29,8 @@ def lambda_update_file(event: dict, context):
     metadata: dict = body['metadata']
 
     primary_key = {
-        CONTENT_METADATA_TB_PK: metadata['username'],
-        CONTENT_METADATA_TB_SK: metadata['uuid']
+        CONTENT_METADATA_TB_PK: metadata[CONTENT_METADATA_TB_PK],
+        CONTENT_METADATA_TB_SK: metadata[CONTENT_METADATA_TB_SK]
     }
 
     # Get the whole object
@@ -47,7 +47,7 @@ def lambda_update_file(event: dict, context):
 
     new_obj: dict = {}
     for k, v in metadata.items():
-        if k not in ['username', 'uuid']:
+        if k not in [CONTENT_METADATA_TB_PK, CONTENT_METADATA_TB_SK]:
             new_obj[k] = v
 
     # Build update expression 
@@ -72,7 +72,7 @@ def lambda_update_file(event: dict, context):
         s3_cli.upload_fileobj(
             Fileobj=io.BytesIO(data),
             Bucket=CONTENT_BUCKET_NAME,
-            Key=metadata['uuid']
+            Key=metadata[CONTENT_METADATA_TB_SK]
         )
 
     return http_response(None, 204)

--- a/src/lambdas/lambda_update_file.py
+++ b/src/lambdas/lambda_update_file.py
@@ -20,6 +20,12 @@ def build_expression(data: Dict):
 
 def lambda_update_file(event: Dict, context):
     body: Dict = json.loads(event['body'])
+    headers: Dict = event['headers']
+
+    username: str = jwt_decode(headers)
+    if not user_exists(username):
+        return http_response("Forbidden", 401)
+    
     metadata: Dict = body['metadata']
 
     primary_key = {

--- a/src/lambdas/lambda_update_file.py
+++ b/src/lambdas/lambda_update_file.py
@@ -1,3 +1,5 @@
+import base64
+import io
 from typing import Dict
 from .common import *
 
@@ -55,5 +57,16 @@ def lambda_update_file(event: Dict, context):
         ExpressionAttributeNames=expression_attr_names,
         ExpressionAttributeValues=python_obj_to_dynamo_obj(expression_attr_vals)
     )
+
+    # Update the contents
+
+    if 'data' in body:
+        data: bytes = base64.b64decode(body['data'])
+
+        s3_cli.upload_fileobj(
+            Fileobj=io.BytesIO(data),
+            Bucket=CONTENT_BUCKET_NAME,
+            Key=metadata['uuid']
+        )
 
     return http_response(None, 204)

--- a/src/lambdas/lambda_update_file.py
+++ b/src/lambdas/lambda_update_file.py
@@ -1,10 +1,10 @@
 import base64
 import io
-from typing import Dict
+
 from .common import *
 
 
-def build_expression(data: Dict):
+def build_expression(data: dict):
     expression_attr_names = {}
     expression_attr_vals = {}
     for i, (k, v) in enumerate(data.items()):
@@ -18,15 +18,15 @@ def build_expression(data: Dict):
     return update_expression, expression_attr_names, expression_attr_vals
 
 
-def lambda_update_file(event: Dict, context):
-    body: Dict = json.loads(event['body'])
-    headers: Dict = event['headers']
+def lambda_update_file(event: dict, context):
+    body: dict = json.loads(event['body'])
+    headers: dict = event['headers']
 
     username: str = jwt_decode(headers)
     if not user_exists(username):
         return http_response("Forbidden", 401)
     
-    metadata: Dict = body['metadata']
+    metadata: dict = body['metadata']
 
     primary_key = {
         CONTENT_METADATA_TB_PK: metadata['username'],
@@ -45,7 +45,7 @@ def lambda_update_file(event: Dict, context):
     
     # Get all fields that were updated (except key fields!)
 
-    new_obj: Dict = {}
+    new_obj: dict = {}
     for k, v in metadata.items():
         if k not in ['username', 'uuid']:
             new_obj[k] = v

--- a/src/lambdas/lambda_update_file.py
+++ b/src/lambdas/lambda_update_file.py
@@ -5,6 +5,52 @@ from .common import *
 def lambda_update_file(event: Dict, context):
     body: Dict = json.loads(event['body'])
     metadata: Dict = body['metadata']
-    metadata_dynamojson: str = python_obj_to_dynamo_obj(metadata)
+
+
+    # TODO: This doesn't change the name. We can't change it normally since 
+    # it's a partition key. Change the dynamodb structure!
+
+    old_key = {
+        CONTENT_METADATA_TB_PK: metadata['old_name']
+    }
+
+    key = {
+        CONTENT_METADATA_TB_PK: metadata['name']
+    }
+
+    # Get everything from the old object
+
+    response = dynamo_cli.get_item(
+        TableName=CONTENT_METADATA_TB_NAME,
+        Key=python_obj_to_dynamo_obj(old_key)
+    )
+
+    if 'Item' not in response:
+        return http_response(f"No element under key {metadata['old_name']} exists!", 404)
+
+    new_obj: Dict = {}
+    for k, v in metadata.items():
+        if k not in ['name', 'old_name']:
+            new_obj[k] = v
+
+    # Update the object
+
+    expression_attr_names = {}
+    expression_attr_vals = {}
+    for i, (k, v) in enumerate(new_obj.items()):
+        expression_attr_names[f'#f{i}'] = k
+        expression_attr_vals[f':f{i}'] = v
+    update_expression = "SET "
+    for i in range(len(expression_attr_vals)):
+        update_expression += f'#f{i} = :f{i}, '
+    update_expression = update_expression[:-2]
+
+    dynamo_cli.update_item(
+        Key=python_obj_to_dynamo_obj(key),
+        TableName=CONTENT_METADATA_TB_NAME,
+        UpdateExpression=update_expression,
+        ExpressionAttributeNames=expression_attr_names,
+        ExpressionAttributeValues=python_obj_to_dynamo_obj(expression_attr_vals)
+    )
 
     return http_response(None, 204)

--- a/src/lambdas/lambda_update_file.py
+++ b/src/lambdas/lambda_update_file.py
@@ -1,0 +1,10 @@
+from typing import Dict
+from .common import *
+
+
+def lambda_update_file(event: Dict, context):
+    body: Dict = json.loads(event['body'])
+    metadata: Dict = body['metadata']
+    metadata_dynamojson: str = python_obj_to_dynamo_obj(metadata)
+
+    return http_response(None, 204)

--- a/src/lambdas/lambda_upload_file.py
+++ b/src/lambdas/lambda_upload_file.py
@@ -24,7 +24,7 @@ def lambda_upload_file(event: dict, context):
     s3_cli.upload_fileobj(
         Fileobj=io.BytesIO(data),
         Bucket=CONTENT_BUCKET_NAME,
-        Key=metadata['uuid']
+        Key=metadata[CONTENT_METADATA_TB_SK]
     )
 
     return http_response(None, 204)

--- a/src/lambdas/lambda_upload_file.py
+++ b/src/lambdas/lambda_upload_file.py
@@ -1,18 +1,18 @@
 import base64
 import io
-from typing import Dict
+
 from .common import *
 
 
-def lambda_upload_file(event: Dict, context):
-    body: Dict = json.loads(event['body'])
-    headers: Dict = event['headers']
+def lambda_upload_file(event: dict, context):
+    body: dict = json.loads(event['body'])
+    headers: dict = event['headers']
 
     username: str = jwt_decode(headers)
     if not user_exists(username):
         return http_response("Forbidden", 401)
      
-    metadata: Dict = body['metadata']
+    metadata: dict = body['metadata']
     metadata_dynamojson: str = python_obj_to_dynamo_obj(metadata)
     data: bytes = base64.b64decode(body['data'])
 

--- a/src/lambdas/lambda_upload_file.py
+++ b/src/lambdas/lambda_upload_file.py
@@ -6,6 +6,12 @@ from .common import *
 
 def lambda_upload_file(event: Dict, context):
     body: Dict = json.loads(event['body'])
+    headers: Dict = event['headers']
+
+    username: str = jwt_decode(headers)
+    if not user_exists(username):
+        return http_response("Forbidden", 401)
+     
     metadata: Dict = body['metadata']
     metadata_dynamojson: str = python_obj_to_dynamo_obj(metadata)
     data: bytes = base64.b64decode(body['data'])

--- a/src/lambdas/lambda_upload_file.py
+++ b/src/lambdas/lambda_upload_file.py
@@ -18,7 +18,7 @@ def lambda_upload_file(event: Dict, context):
     s3_cli.upload_fileobj(
         Fileobj=io.BytesIO(data),
         Bucket=CONTENT_BUCKET_NAME,
-        Key=metadata['name']
+        Key=metadata['uuid']
     )
 
     return http_response(None, 204)

--- a/src/service/delete_file.py
+++ b/src/service/delete_file.py
@@ -4,7 +4,7 @@ import requests
 import src.service.session as session
 
 
-def delete_file(file_uuid: str):
+def delete_file(file_uuid: str) -> requests.Response:
     payload = {
         "username": session.get_username(),
         "uuid": file_uuid,
@@ -12,5 +12,6 @@ def delete_file(file_uuid: str):
     payload_json = json.dumps(payload, default=str)
 
     header = {'Authorization': f'Bearer {session.get_jwt()}'}
-    result = requests.delete(f'{BASE_URL}/file', data=payload_json, headers=header)
-    print(result.json())
+    result: requests.Response = requests.delete(f'{BASE_URL}/file', data=payload_json, headers=header)
+
+    return result

--- a/src/service/delete_file.py
+++ b/src/service/delete_file.py
@@ -1,0 +1,15 @@
+import json
+from src.service.session import BASE_URL
+import requests
+import src.service.session as session
+
+
+def delete_file(file_uuid: str):
+    payload = {
+        "username": session.get_username(),
+        "uuid": file_uuid,
+    }
+    payload_json = json.dumps(payload, default=str)
+
+    result = requests.delete(f'{BASE_URL}/file', data=payload_json)
+    print(result)

--- a/src/service/delete_file.py
+++ b/src/service/delete_file.py
@@ -11,5 +11,6 @@ def delete_file(file_uuid: str):
     }
     payload_json = json.dumps(payload, default=str)
 
-    result = requests.delete(f'{BASE_URL}/file', data=payload_json)
-    print(result)
+    header = {'Authorization': f'Bearer {session.get_jwt()}'}
+    result = requests.delete(f'{BASE_URL}/file', data=payload_json, headers=header)
+    print(result.json())

--- a/src/service/list_files.py
+++ b/src/service/list_files.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+import json
+from src.service.session import BASE_URL
+import requests
+import src.service.session as session
+from src.service.upload_file import FileData
+
+
+def list_files():
+    payload = {
+        "username": session.get_username()
+    }
+    payload_json = json.dumps(payload, default=str)
+
+    r = requests.get(f'{BASE_URL}/file', data=payload_json)
+
+    status_code = r.status_code
+
+    if status_code == 200:
+        body = r.json()
+        res_items = [
+            FileData(
+                username=i['username'],
+                uuid=i['uuid'],
+                name=i['name'],
+                type=i.get('type', ''),
+                desc=i.get('desc', ''),
+                tags=i.get('tags', []),
+                size=i.get('size', 0),
+                upload_date=datetime.fromisoformat(i.get('uploadDate', "")),
+                last_modified=datetime.fromisoformat(i.get('modificationDate', "")),
+                creation_date=datetime.fromisoformat(i.get('creationDate', "")),
+            ) for i in body
+        ]
+
+        return res_items
+    else:
+        return []
+        # print("TODO Error case", body)

--- a/src/service/list_files.py
+++ b/src/service/list_files.py
@@ -12,7 +12,8 @@ def list_files():
     }
     payload_json = json.dumps(payload, default=str)
 
-    r = requests.get(f'{BASE_URL}/file', data=payload_json)
+    header = {'Authorization': f'Bearer {session.get_jwt()}'}
+    r = requests.get(f'{BASE_URL}/file', data=payload_json, headers=header)
 
     status_code = r.status_code
 

--- a/src/service/register_user.py
+++ b/src/service/register_user.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import json
-from typing import Dict
+
 
 import requests
 from src.service.session import BASE_URL
@@ -24,7 +24,7 @@ TB_USER_PK = 'username'
 LAMBDA_NAME = "register"
 
 
-def make_payload_from(user: User) -> Dict:
+def make_payload_from(user: User) -> dict:
     user_dict = vars(user) # Be careful if you ever add anything fancy to `User`
 
     return user_dict

--- a/src/service/session.py
+++ b/src/service/session.py
@@ -20,3 +20,8 @@ def get_username() -> str:
 
     decoded = jwt.decode(token, options={"verify_signature": False})
     return decoded['username']
+
+
+def get_jwt() -> str:
+    with open(TOKEN_FILENAME, "r") as token_file:
+        return token_file.readline().strip()

--- a/src/service/session.py
+++ b/src/service/session.py
@@ -13,8 +13,7 @@ TOKEN_FILENAME = "user_token.txt"
 def get_username() -> str:
     token = ""
     try:
-        with open(TOKEN_FILENAME, "r") as token_file:
-            token = token_file.readline().strip()
+        token = get_jwt()
     except FileNotFoundError:
         pass
 

--- a/src/service/session.py
+++ b/src/service/session.py
@@ -1,6 +1,22 @@
 from os import environ
+import jwt
 
 if "BASE_URL" not in environ:
     raise Exception("Please add BASE_URL to env")
 BASE_URL = environ["BASE_URL"]
 print("Make sure to change BASE_URL in your env when generating a new one or restarting localstack.")
+
+
+TOKEN_FILENAME = "user_token.txt"
+
+
+def get_username() -> str:
+    token = ""
+    try:
+        with open(TOKEN_FILENAME, "r") as token_file:
+            token = token_file.readline().strip()
+    except FileNotFoundError:
+        pass
+
+    decoded = jwt.decode(token, options={"verify_signature": False})
+    return decoded['username']

--- a/src/service/update_file.py
+++ b/src/service/update_file.py
@@ -1,0 +1,40 @@
+import base64
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import os
+from pathlib import Path
+from typing import Dict, List
+from src.service.session import BASE_URL
+import requests
+
+
+def make_metadata(name: str, desc: str, tags: List[str]) -> Dict:
+    metadata = {
+        'name': name,
+        'desc': desc,
+        'tags': tags,
+        'modificationDate': datetime.now(),
+    }
+
+    return metadata
+
+
+def make_data_base64(fname: str) -> bytes:
+    file_data_base64: bytes = None
+    with open(fname, 'rb') as f:
+        file_data_base64 = base64.b64encode(f.read()).decode()
+    return file_data_base64
+
+
+def update_file(fname: str, desc: str, tags: List[str]):
+    metadata: Dict = make_metadata(fname, desc, tags)
+    #data_b64: bytes = make_data_base64(fname)
+
+    payload = {
+        "metadata": metadata,
+        #"data": data_b64,
+    }
+    payload_json = json.dumps(payload, default=str)
+
+    requests.put(f'{BASE_URL}/file', data=payload_json)

--- a/src/service/update_file.py
+++ b/src/service/update_file.py
@@ -7,10 +7,13 @@ from pathlib import Path
 from typing import Dict, List
 from src.service.session import BASE_URL
 import requests
+import boto3
+from os import environ
 
 
-def make_metadata(name: str, desc: str, tags: List[str]) -> Dict:
+def make_metadata(old_name: str, name: str, desc: str, tags: List[str]) -> Dict:
     metadata = {
+        'old_name': old_name,
         'name': name,
         'desc': desc,
         'tags': tags,
@@ -27,8 +30,9 @@ def make_data_base64(fname: str) -> bytes:
     return file_data_base64
 
 
-def update_file(fname: str, desc: str, tags: List[str]):
-    metadata: Dict = make_metadata(fname, desc, tags)
+
+def update_file(old_name: str, name: str, desc: str, tags: List[str]):
+    metadata: Dict = make_metadata(old_name, name, desc, tags)
     #data_b64: bytes = make_data_base64(fname)
 
     payload = {

--- a/src/service/update_file.py
+++ b/src/service/update_file.py
@@ -52,4 +52,5 @@ def update_file(uuid: str, new_name: str, new_desc: str, new_tags: List[str], ne
 
     print(f"Upading http://localhost:4566/content/{metadata['uuid']}")
 
-    requests.put(f'{BASE_URL}/file', data=payload_json)
+    header = {'Authorization': f'Bearer {session.get_jwt()}'}
+    requests.put(f'{BASE_URL}/file', data=payload_json, headers=header)

--- a/src/service/update_file.py
+++ b/src/service/update_file.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import json
 import os
 from pathlib import Path
-, List
+from typing import List
 from src.service.session import BASE_URL
 import requests
 import boto3
@@ -38,7 +38,7 @@ def update_file(uuid: str, new_name: str, new_desc: str, new_tags: List[str], ne
     metadata: dict = make_metadata(session.get_username(), uuid, new_name, new_desc, new_tags)
     payload = {}
 
-    if new_fname is not None:
+    if new_fname is not None and new_fname != "":
         data_b64: bytes = make_data_base64(new_fname)
         payload['data'] = data_b64
 

--- a/src/service/update_file.py
+++ b/src/service/update_file.py
@@ -10,6 +10,7 @@ import requests
 import boto3
 from os import environ
 import src.service.session as session
+import src.service.upload_file as upload_file
 
 
 def make_metadata(username: str, uuid: str, new_name: str, new_desc: str, new_tags: List[str]) -> Dict:
@@ -33,10 +34,22 @@ def make_data_base64(fname: str) -> bytes:
 
 
 
-def update_file(uuid: str, new_name: str, new_desc: str, new_tags: List[str]):   
+def update_file(uuid: str, new_name: str, new_desc: str, new_tags: List[str], new_fname: str | None):   
     metadata: Dict = make_metadata(session.get_username(), uuid, new_name, new_desc, new_tags)
-    payload = {
-        "metadata": metadata
-    }
+    payload = {}
+
+    if new_fname is not None:
+        data_b64: bytes = make_data_base64(new_fname)
+        payload['data'] = data_b64
+
+        metadata_2: Dict = upload_file.make_metadata(new_fname, new_desc, new_tags)
+        metadata['size'] = metadata_2['size']
+        metadata['type'] = metadata_2['type']
+
+    payload['metadata'] = metadata
+
     payload_json = json.dumps(payload, default=str)
+
+    print(payload_json)
+
     requests.put(f'{BASE_URL}/file', data=payload_json)

--- a/src/service/update_file.py
+++ b/src/service/update_file.py
@@ -31,14 +31,15 @@ def make_data_base64(fname: str) -> bytes:
 
 
 
-def update_file(old_name: str, name: str, desc: str, tags: List[str]):
+def update_file(old_name: str, name: str, desc: str, tags: List[str], new_fname: str):
     metadata: Dict = make_metadata(old_name, name, desc, tags)
-    #data_b64: bytes = make_data_base64(fname)
 
     payload = {
         "metadata": metadata,
-        #"data": data_b64,
     }
-    payload_json = json.dumps(payload, default=str)
+    if new_fname != None:
+        data_b64: bytes = make_data_base64(new_fname)
+        payload['data'] = data_b64
 
+    payload_json = json.dumps(payload, default=str)
     requests.put(f'{BASE_URL}/file', data=payload_json)

--- a/src/service/update_file.py
+++ b/src/service/update_file.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import json
 import os
 from pathlib import Path
-from typing import Dict, List
+, List
 from src.service.session import BASE_URL
 import requests
 import boto3
@@ -13,7 +13,7 @@ import src.service.session as session
 import src.service.upload_file as upload_file
 
 
-def make_metadata(username: str, uuid: str, new_name: str, new_desc: str, new_tags: List[str]) -> Dict:
+def make_metadata(username: str, uuid: str, new_name: str, new_desc: str, new_tags: List[str]) -> dict:
     metadata = {
         'username': username,
         'uuid': uuid,
@@ -35,14 +35,14 @@ def make_data_base64(fname: str) -> bytes:
 
 
 def update_file(uuid: str, new_name: str, new_desc: str, new_tags: List[str], new_fname: str | None):   
-    metadata: Dict = make_metadata(session.get_username(), uuid, new_name, new_desc, new_tags)
+    metadata: dict = make_metadata(session.get_username(), uuid, new_name, new_desc, new_tags)
     payload = {}
 
     if new_fname is not None:
         data_b64: bytes = make_data_base64(new_fname)
         payload['data'] = data_b64
 
-        metadata_2: Dict = upload_file.make_metadata(new_fname, new_desc, new_tags)
+        metadata_2: dict = upload_file.make_metadata(new_fname, new_desc, new_tags)
         metadata['size'] = metadata_2['size']
         metadata['type'] = metadata_2['type']
 

--- a/src/service/update_file.py
+++ b/src/service/update_file.py
@@ -9,14 +9,16 @@ from src.service.session import BASE_URL
 import requests
 import boto3
 from os import environ
+import src.service.session as session
 
 
-def make_metadata(old_name: str, name: str, desc: str, tags: List[str]) -> Dict:
+def make_metadata(username: str, uuid: str, new_name: str, new_desc: str, new_tags: List[str]) -> Dict:
     metadata = {
-        'old_name': old_name,
-        'name': name,
-        'desc': desc,
-        'tags': tags,
+        'username': username,
+        'uuid': uuid,
+        'name': new_name,
+        'desc': new_desc,
+        'tags': new_tags,
         'modificationDate': datetime.now(),
     }
 
@@ -31,15 +33,10 @@ def make_data_base64(fname: str) -> bytes:
 
 
 
-def update_file(old_name: str, name: str, desc: str, tags: List[str], new_fname: str):
-    metadata: Dict = make_metadata(old_name, name, desc, tags)
-
+def update_file(uuid: str, new_name: str, new_desc: str, new_tags: List[str]):   
+    metadata: Dict = make_metadata(session.get_username(), uuid, new_name, new_desc, new_tags)
     payload = {
-        "metadata": metadata,
+        "metadata": metadata
     }
-    if new_fname != None:
-        data_b64: bytes = make_data_base64(new_fname)
-        payload['data'] = data_b64
-
     payload_json = json.dumps(payload, default=str)
     requests.put(f'{BASE_URL}/file', data=payload_json)

--- a/src/service/update_file.py
+++ b/src/service/update_file.py
@@ -50,6 +50,6 @@ def update_file(uuid: str, new_name: str, new_desc: str, new_tags: List[str], ne
 
     payload_json = json.dumps(payload, default=str)
 
-    print(payload_json)
+    print(f"Upading http://localhost:4566/content/{metadata['uuid']}")
 
     requests.put(f'{BASE_URL}/file', data=payload_json)

--- a/src/service/upload_file.py
+++ b/src/service/upload_file.py
@@ -77,4 +77,5 @@ def upload_file(fname: str, desc: str, tags: List[str]):
 
     print(f"Uploading http://localhost:4566/content/{metadata['uuid']}")
 
-    requests.post(f'{BASE_URL}/file', data=payload_json)
+    header = {'Authorization': f'Bearer {session.get_jwt()}'}
+    requests.post(f'{BASE_URL}/file', data=payload_json, headers=header)

--- a/src/service/upload_file.py
+++ b/src/service/upload_file.py
@@ -13,6 +13,8 @@ import src.service.session as session
 
 @dataclass
 class FileData:
+    username: str
+    uuid: str
     name: str
     type: str
     desc: str
@@ -89,6 +91,8 @@ def list_files():
         body = r.json()
         res_items = [
             FileData(
+                username=i['username'],
+                uuid=i['uuid'],
                 name=i['name'],
                 type=i.get('type', ''),
                 desc=i.get('desc', ''),

--- a/src/service/upload_file.py
+++ b/src/service/upload_file.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import json
 import os
 from pathlib import Path
-from typing import Dict, List
+, List
 from src.service.session import BASE_URL
 import requests
 import uuid
@@ -33,7 +33,7 @@ TB_META_PK = 'name'
 TB_META_SK = None
 
 
-def make_metadata(fname: str, desc: str, tags: List[str]) -> Dict:
+def make_metadata(fname: str, desc: str, tags: List[str]) -> dict:
     stat: os.stat_result = os.stat(fname)
     size_in_bytes = stat.st_size
     creation_time = datetime.fromtimestamp(stat.st_ctime)
@@ -66,7 +66,7 @@ def make_data_base64(fname: str) -> bytes:
 
 
 def upload_file(fname: str, desc: str, tags: List[str]):
-    metadata: Dict = make_metadata(fname, desc, tags)
+    metadata: dict = make_metadata(fname, desc, tags)
     data_b64: bytes = make_data_base64(fname)
 
     payload = {

--- a/src/service/upload_file.py
+++ b/src/service/upload_file.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import json
 import os
 from pathlib import Path
-, List
+from typing import List
 from src.service.session import BASE_URL
 import requests
 import uuid

--- a/src/service/upload_file.py
+++ b/src/service/upload_file.py
@@ -8,6 +8,7 @@ from typing import Dict, List
 from src.service.session import BASE_URL
 import requests
 import uuid
+import src.service.session as session
 
 
 @dataclass
@@ -39,7 +40,7 @@ def make_metadata(fname: str, desc: str, tags: List[str]) -> Dict:
     just_name = Path(fname).stem
 
     metadata = {
-        'username': 'TODO',
+        'username': session.get_username(),
         'uuid': str(uuid.uuid4()),
 
         'name': just_name,
@@ -77,7 +78,7 @@ def upload_file(fname: str, desc: str, tags: List[str]):
 
 def list_files():
     payload = {
-        "username": "TODO"
+        "username": session.get_username()
     }
     payload_json = json.dumps(payload, default=str)
 

--- a/src/service/upload_file.py
+++ b/src/service/upload_file.py
@@ -78,35 +78,3 @@ def upload_file(fname: str, desc: str, tags: List[str]):
     print(f"Uploading http://localhost:4566/content/{metadata['uuid']}")
 
     requests.post(f'{BASE_URL}/file', data=payload_json)
-
-
-def list_files():
-    payload = {
-        "username": session.get_username()
-    }
-    payload_json = json.dumps(payload, default=str)
-
-    r = requests.get(f'{BASE_URL}/file', data=payload_json)
-    status_code = r.status_code
-
-    if status_code == 200:
-        body = r.json()
-        res_items = [
-            FileData(
-                username=i['username'],
-                uuid=i['uuid'],
-                name=i['name'],
-                type=i.get('type', ''),
-                desc=i.get('desc', ''),
-                tags=i.get('tags', []),
-                size=i.get('size', 0),
-                upload_date=datetime.fromisoformat(i.get('uploadDate', "")),
-                last_modified=datetime.fromisoformat(i.get('modificationDate', "")),
-                creation_date=datetime.fromisoformat(i.get('creationDate', "")),
-            ) for i in body
-        ]
-
-        return res_items
-    else:
-        return []
-        # print("TODO Error case", body)

--- a/src/service/upload_file.py
+++ b/src/service/upload_file.py
@@ -75,6 +75,8 @@ def upload_file(fname: str, desc: str, tags: List[str]):
     }
     payload_json = json.dumps(payload, default=str)
 
+    print(f"Uploading http://localhost:4566/content/{metadata['uuid']}")
+
     requests.post(f'{BASE_URL}/file', data=payload_json)
 
 

--- a/src/service/upload_file.py
+++ b/src/service/upload_file.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Dict, List
 from src.service.session import BASE_URL
 import requests
+import uuid
 
 
 @dataclass
@@ -38,6 +39,9 @@ def make_metadata(fname: str, desc: str, tags: List[str]) -> Dict:
     just_name = Path(fname).stem
 
     metadata = {
+        'username': 'TODO',
+        'uuid': str(uuid.uuid4()),
+
         'name': just_name,
         'size': size_in_bytes,
         'creationDate': creation_time,
@@ -72,7 +76,12 @@ def upload_file(fname: str, desc: str, tags: List[str]):
 
 
 def list_files():
-    r = requests.get(f'{BASE_URL}/file')
+    payload = {
+        "username": "TODO"
+    }
+    payload_json = json.dumps(payload, default=str)
+
+    r = requests.get(f'{BASE_URL}/file', data=payload_json)
     status_code = r.status_code
 
     if status_code == 200:
@@ -84,9 +93,9 @@ def list_files():
                 desc=i.get('desc', ''),
                 tags=i.get('tags', []),
                 size=i.get('size', 0),
-                upload_date=datetime.fromisoformat(i.get('upload_date', "")),
-                last_modified=datetime.fromisoformat(i.get('last_modified', "")),
-                creation_date=datetime.fromisoformat(i.get('creation_date', "")),
+                upload_date=datetime.fromisoformat(i.get('uploadDate', "")),
+                last_modified=datetime.fromisoformat(i.get('modificationDate', "")),
+                creation_date=datetime.fromisoformat(i.get('creationDate', "")),
             ) for i in body
         ]
 


### PR DESCRIPTION
Closes #13 #14 #22 
User can update metadata (name, description, tags) and the file content itself.
The file database has changed:

```
+-----------+------+
| PARTITION | SORT |      
|    KEY    | KEY  |
+-----------+------+------+-----+  
| username  | uuid | name | ... |
+-----------+------+------+-----+
|           |      |      |     |
```

`username` is the username of the user who uploaded the file.
`uuid` is generated when the file is uploaded and it uniquely describes a file in the whole system.

list_files() now returns only the files for the given username, so each user has his own "drive".

To test whether the file contents are properly updated, check stdout for our client, it'll print out a URL where you can download the file (you have to change its extension to view it) <-- this is a hint for how we're going to do downloading files (1.11).

**Problem**: unique file name per album is no longer enforced. We have to do it manually. See: #23 