### PR TITLE
1.11 download

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -132,6 +132,15 @@ functions:
       - http:
           path: album
           method: get
+  downloadFile:
+    handler: src/lambdas/lambda_download_file.lambda_download_file
+    package:
+      patterns:
+        - 'src/lambdas/lambda_download_file.py'
+    events:
+      - http:
+          path: file-download
+          method: get
 
 
 resources:

--- a/serverless.yml
+++ b/serverless.yml
@@ -213,3 +213,9 @@ resources:
       Type: AWS::S3::Bucket
       Properties:
         BucketName: content
+        AccessControl: Private # This doesn't work?
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: true
+          BlockPublicPolicy: true
+          IgnorePublicAcls: true
+          RestrictPublicBuckets: true

--- a/src/gui/dashboard/overview_screen.py
+++ b/src/gui/dashboard/overview_screen.py
@@ -17,6 +17,8 @@ from src.service.move_file import move_file
 from src.service.get_albums import get_albums
 from src.service.download_file import download_file
 
+FILE_TYPE_ALBUM = 'Album'
+
 
 @dataclass
 class MoveFilePopup(QDialog):
@@ -235,6 +237,8 @@ class FileEdit(QGroupBox):
 
         self.selected_file = file
 
+        self.btn_download.setEnabled(file.type != FILE_TYPE_ALBUM)
+
     def on_click_update(self):
         new_name: str = self.txt_name.text()
         new_desc: str = self.txt_desc.toPlainText()
@@ -422,7 +426,7 @@ class OverviewScreen(QWidget):
         pixmapi = QStyle.StandardPixmap.SP_FileIcon
         fullname = f"{file.name} {file.type}"
 
-        if file.type == 'Album':
+        if file.type == FILE_TYPE_ALBUM:
             pixmapi = QStyle.StandardPixmap.SP_DirIcon
             fullname = f"{file.name}"
 
@@ -441,7 +445,7 @@ class OverviewScreen(QWidget):
 
     def on_doubleclick_item(self, item: QModelIndex):
         file: FileData = self.files[item.row()]
-        if file.type == 'Album':
+        if file.type == FILE_TYPE_ALBUM:
             self.open_folder(file.uuid)
 
     def on_click_add_album(self):

--- a/src/gui/dashboard/overview_screen.py
+++ b/src/gui/dashboard/overview_screen.py
@@ -302,7 +302,7 @@ class FileEdit(QGroupBox):
         self.btn_move_dialog.show()
 
     def on_click_download(self):
-        fname, _ = QFileDialog.getSaveFileName(self, 'Download File')
+        fname, _ = QFileDialog.getSaveFileName(self, 'Download File', directory = f'{self.selected_file.name}{self.selected_file.type}')
         if fname == "":
             fname = None
 

--- a/src/lambdas/lambda_download_file.py
+++ b/src/lambdas/lambda_download_file.py
@@ -47,8 +47,6 @@ def lambda_download_file(event: dict, context):
         return http_response("Forbidden", 401)
  
     file_uuid = body['file_uuid']
-    bucket_uri = f'{CONTENT_BUCKET_NAME}/{file_uuid}'
-    bucket_key = file_uuid
     file = get_file(username, file_uuid)
 
     if file is None:

--- a/src/lambdas/lambda_download_file.py
+++ b/src/lambdas/lambda_download_file.py
@@ -1,0 +1,58 @@
+from .common import *
+import io
+
+
+def get_file(username: str, file_uuid: str):
+    # TODO: Sharing: check if file is part of shared album hierarchy or if
+    # the file is directly shared.
+
+    statement = f"""
+        SELECT * FROM {CONTENT_METADATA_TB_NAME}
+        WHERE
+            {CONTENT_METADATA_TB_PK}=? AND
+            {CONTENT_METADATA_TB_SK}=?
+    """
+    parameters = python_obj_to_dynamo_obj([username, file_uuid])
+
+    response = dynamo_cli.execute_statement(    
+        Statement=statement,
+        Parameters=parameters
+    )
+
+    for o in response['Items']:
+        obj = dynamo_obj_to_python_obj(o)
+        return obj # There should be only 1.
+    return None
+
+
+def download_file(file_uuid: str) -> str:
+    stream = io.BytesIO()
+    s3_cli.download_fileobj(
+        Bucket=CONTENT_BUCKET_NAME,
+        Key=file_uuid,
+        Fileobj=stream
+    )
+    stream.seek(0)
+
+    bytes_str = base64.b64encode(stream.getvalue()).decode()
+    return bytes_str
+
+
+def lambda_download_file(event: dict, context):
+    body: dict = json.loads(event['body'])
+    headers: dict = event['headers']
+
+    username: str = jwt_decode(headers)
+    if not user_exists(username):
+        return http_response("Forbidden", 401)
+ 
+    file_uuid = body['file_uuid']
+    bucket_uri = f'{CONTENT_BUCKET_NAME}/{file_uuid}'
+    bucket_key = file_uuid
+    file = get_file(username, file_uuid)
+
+    if file is None:
+        return http_response("File not found", 404)
+
+    bytes_str = download_file(file_uuid)
+    return http_response(bytes_str, 200)

--- a/src/service/download_file.py
+++ b/src/service/download_file.py
@@ -1,0 +1,19 @@
+import json
+from src.service.session import BASE_URL
+import requests
+import src.service.session as session
+import base64
+
+
+def download_file(file_uuid: str) -> bytes:
+    payload = {
+        "file_uuid": file_uuid
+    }
+    payload_json = json.dumps(payload, default=str)
+    header = {'Authorization': f'Bearer {session.get_jwt()}'}
+    result: requests.Response = requests.get(f'{BASE_URL}/file-download', data=payload_json, headers=header)
+
+    if not result.ok:
+        print(result)
+
+    return base64.b64decode(result.json())


### PR DESCRIPTION
Closes #29 

There's a download button for downloading files. Folders cannot be downloaded (although the gui has the button readily available, we should do something about the gui being misleading).

@filipkontic Check the TODO for sharing content in `lambda_download_file.py`. Right now it only checks if `username` is the owner of `file_uuid`.

@swopl The bucket has public access (downloadable through http://localhost:4566/content/[uuid]) despite cd249a9. Is there something else I should have done?